### PR TITLE
Fix typos

### DIFF
--- a/content/Day3_Practicals.md
+++ b/content/Day3_Practicals.md
@@ -47,7 +47,10 @@ And if the predictions are not as accurate as you want them, it is an ideal vide
 
 Once, you extracted outliers you can fix them manually:
 
-<pre lang="python">pythondeeplabcut.refine_labels(conﬁg_path)</pre>
+<pre lang="python">deeplabcut.refine_labels(conﬁg_path)</pre>
+
+Finally, you should merge the original training dataset with the newly refined data. The iteration parameter in the `config.yaml` file is updated automatically.
+<pre lang="python">deeplabcut.merge_datasets(config_path)</pre>
 
 
 This will grow your dataset to better comprise the variablity. Then you can re-train 🚂 your model. You can either train de-novo, or use the prior weights (which is faster and usually preferred).
@@ -56,7 +59,6 @@ This will grow your dataset to better comprise the variablity. Then you can re-t
 ## Let’s talk 📲
 
 - If you are interested in learning further about active learning approaches, check out [this blog post!](https://deeplabcut.medium.com/exploring-active-learning-with-deeplabcut-an-ai-residents-journey-e441bbd5a71c) 
->>>>>>> 1fefc9404866074b95e6007402b5f26f21f92f5a
 
 
 TODO_TA: What else?

--- a/content/installation.md
+++ b/content/installation.md
@@ -9,7 +9,7 @@ In brief, **if you do not have a GPU on your machine**, all you need to do is:
 - install Python - <a href="https://deeplabcut.github.io/DeepLabCut/docs/installation.html#step-1-you-need-to-have-python-installed" target="_blank">Step 1 in the DLC installation guide</a> describes the easiest way to do this;
 - install DeepLabCut - <a href="https://deeplabcut.github.io/DeepLabCut/docs/installation.html#step-2-please-use-our-supplied-conda-environment" target="_blank">Step 2 in the DLC installation guide</a> explains what to do depending on your operating system.
 
-For the steps that require a GPU, you will use DeepLabCut on Google Colab.
+For the steps that require a GPU, you can use DeepLabCut on <a href="https://colab.research.google.com/" target="_blank">Google Colab</a> 😉!
 
 **If you have an Apple M1/M2 GPU**, have a look at <a href="https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/installation.md#install-anaconda-or-use-miniconda3-ideal-for-macos-users" target="_blank">this MacOS-specific guidance</a>!
 
@@ -25,7 +25,7 @@ If you use Windows OS and **do not** have other versions of CUDA installed:
     - you can check which driver is installed by typing `nvidia-smi` in the terminal
     - check that your NVIDIA driver <a href="https://docs.nvidia.com/deploy/cuda-compatibility/index.html#minor-version-compatibility" target="_blank">will work with CUDA 11.x</a>!
 - set up CUDA - <a href="https://medium.com/analytics-vidhya/installing-cuda-and-cudnn-on-windows-d44b8e9876b5" target="_blank">this medium article</a> details the steps involved
-    - the most recent version of TensforFlow (TF-2.10 which will get installed along with DeepLabCut) <a href="" target="_blank">works with CUDA-11.2</a>
+    - the most recent version of TensforFlow (TF-2.10 which will get installed along with DeepLabCut) <a href="https://www.tensorflow.org/install/source_windows#gpu" target="_blank">works with CUDA-11.2</a>
     - get your Visual Studio 2019 (free) Community version <a href="https://my.visualstudio.com/Downloads?q=visual%20studio%202019&wt.mc_id=o~msft~vscom~older-downloads" target="_blank">here</a>
     - get CUDA-11.2 (or another version if needed) <a href="https://developer.nvidia.com/cuda-toolkit-archive" target="_blank">here</a>
     - get cuDNN-8.1 (or another version if needed) <a href="https://developer.nvidia.com/rdp/cudnn-archive" target="_blank">here</a> - you will need to create an NVIDIA developer profile 
@@ -40,8 +40,6 @@ If you use Windows OS and **do** have other versions of CUDA installed:
 - verify that your GPU is recognised by running `python3 -c "import tensorflow as tf; print(tf.config.list_physical_devices('GPU'))"`
 
 Something gone awry? Check out these <a href="https://deeplabcut.github.io/DeepLabCut/docs/installation.html#troubleshooting" target="_blank">troubleshooting tips</a> and reach out to teaching assistants!
-
-You could also use DeepLabCut on [Google Colab](https://colab.research.google.com/). In that case, you don't need to install it on your computer 😉!
 
 [Let's go  back 🔙](../README.md).
 


### PR DESCRIPTION
`installation.md`
- added a link where it was missing
- deleted a ~duplicate sentence about google colab

`Day3_Practicals.md`
- fixed a typo in a python command
- added `deeplabcut.merge_datasets()` as a final step in the walk-through
- deleted an out-of-place sequence of numbers and letters at the bottom of the page